### PR TITLE
Fix CI: Update deprecated GitHub Actions to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
         components: rustfmt, clippy
     
     - name: Cache cargo dependencies
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: |
           ~/.cargo/registry
@@ -74,7 +74,7 @@ jobs:
       run: cargo build --release
     
     - name: Upload artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: altcha-server-linux
         path: target/release/altcha-server


### PR DESCRIPTION
- Update actions/upload-artifact from v3 to v4
- Update actions/cache from v3 to v4
- Resolve deprecation warnings

## Description

Cleaning up CI to go 



